### PR TITLE
Notify user on panel reactivation

### DIFF
--- a/handlers/sudo_handlers.py
+++ b/handlers/sudo_handlers.py
@@ -2994,6 +2994,11 @@ async def manage_action_activate(callback: CallbackQuery):
             f"🔑 {'پسورد بازیابی شد' if password_restored else 'پسورد قبلی در دسترس نبود'}\n"
             f"👥 کاربران فعال‌شده: {users_reactivated}"
         )
+        try:
+            # Notify affected admin about reactivation (was missing in manage flow)
+            await notify_admin_reactivation_utils(callback.bot, admin.user_id, callback.from_user.id)
+        except Exception as e:
+            logger.warning(f"Failed to notify admin {admin.user_id} about reactivation: {e}")
     except Exception as e:
         text = f"❌ خطا در فعالسازی: {e}"
     await callback.message.edit_text(text, reply_markup=_manage_back_keyboard(admin_id))


### PR DESCRIPTION
Add reactivation notification for panels reactivated via the 'Manage > Activate' flow.

The "Manage > Activate" flow was reactivating user panels without sending a notification to the affected admin, leading to a lack of communication about the panel's status change. This PR rectifies that by adding the missing notification call.

---
<a href="https://cursor.com/background-agent?bcId=bc-f432ab1c-07f7-4100-9371-bd87afa4e277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f432ab1c-07f7-4100-9371-bd87afa4e277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

