### PR TITLE
Investigate user panel time extension bug

### DIFF
--- a/marzban_api.py
+++ b/marzban_api.py
@@ -749,6 +749,13 @@ class MarzbanAPI:
             headers = await self.get_headers()
             
             logger.debug(f"Modifying user {username} in Marzban...")
+
+            # Soft-audit: warn if expire field is being changed, to trace unexpected extensions
+            try:
+                if any(k.lower() == "expire" for k in user_data.keys()):
+                    logger.warning(f"modify_user called with expire for {username}: {user_data.get('expire')}")
+            except Exception:
+                pass
             
             async with httpx.AsyncClient(timeout=config.API_TIMEOUT) as client:
                 response = await client.put(


### PR DESCRIPTION
Add audit logging to track changes to admin time limits and user expiry.

This PR introduces instrumentation to diagnose an issue where user time is unexpectedly extended by one month, potentially during hourly backups. Audit logs will now record changes to `max_total_time` and `created_at` for admins, and a warning will be logged if `marzban_api.modify_user` is called with an `expire` field.

---
<a href="https://cursor.com/background-agent?bcId=bc-09c9c5ad-3b89-48c4-a428-e5a635615433">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09c9c5ad-3b89-48c4-a428-e5a635615433">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

