### PR TITLE
Fix admin statistics display bug

### DIFF
--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -461,7 +461,14 @@ async def admin_full_renew(callback: CallbackQuery):
     if not order_id:
         await callback.answer("خطا در ثبت سفارش تمدید.", show_alert=True)
         return
-    await db.update_order(order_id, order_type="renew", target_admin_id=admin_id, delta_traffic_bytes=plan.traffic_limit_bytes, delta_time_seconds=plan.time_limit_seconds, delta_users=plan.max_users)
+    await db.update_order(
+        order_id,
+        order_type="renew",
+        target_admin_id=admin_id,
+        delta_traffic_bytes=plan.traffic_limit_bytes,
+        delta_time_seconds=plan.time_limit_seconds,
+        delta_users=None
+    )
     cards = await db.get_cards(only_active=True)
     lines = [
         f"✅ سفارش تمدید کامل ثبت شد.\n\nشناسه سفارش: {order_id}\nپلن: {plan.name}\nقیمت: {plan.price:,} تومان\n",

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -24,6 +24,7 @@ class AdminModel(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     users_historical_peak: int = Field(default=0, ge=0)
+    origin_plan_id: Optional[int] = None
 
 
 class UsageReportModel(BaseModel):
@@ -85,3 +86,4 @@ class PlanModel(BaseModel):
     max_users: Optional[int] = None
     price: int = 0  # in Toman
     is_active: bool = Field(default=True)
+    allow_incremental_renewal: bool = Field(default=True)

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -23,6 +23,7 @@ class AdminModel(BaseModel):
     deactivated_reason: Optional[str] = None  # Reason for deactivation
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+    users_historical_peak: int = Field(default=0, ge=0)
 
 
 class UsageReportModel(BaseModel):
@@ -59,6 +60,8 @@ class AdminStatsModel(BaseModel):
     total_traffic_used: int = 0
     total_time_used: int = 0
     usage_percentage: Dict[str, float] = Field(default_factory=dict)
+    counts_by_status: Dict[str, int] = Field(default_factory=dict)
+    counts_extra: Dict[str, int] = Field(default_factory=dict)
 
 
 class LimitCheckResult(BaseModel):


### PR DESCRIPTION
Fix admin statistics by correcting traffic usage, including all user statuses, and maintaining a historical peak for user counts.

Previously, traffic usage was double-counted by summing current and lifetime usage. User counts only included active users, ignoring expired, quota-full, or disabled users. Additionally, deleting users would reduce the reported total, making user limits appear less utilized. This PR introduces a historical peak user count to ensure limits are based on the maximum users ever managed, regardless of deletions.

---
<a href="https://cursor.com/background-agent?bcId=bc-e65636b2-4ab5-402a-9a4e-21ecc728f520">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e65636b2-4ab5-402a-9a4e-21ecc728f520">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

