### PR TITLE
Fix unexpected keyword argument in BoldFixBot

### DIFF
--- a/utils/bold_fix_bot.py
+++ b/utils/bold_fix_bot.py
@@ -100,7 +100,7 @@ class BoldFixBot(Bot):
             pass
         return await super().edit_message_media(media, chat_id, message_id, inline_message_id, *args, **kwargs)
 
-    async def __call__(self, method):
+    async def __call__(self, method, *args: Any, **kwargs: Any):
         """
         Intercept all API method calls to ensure Markdown-like bold/italic/code
         are converted to Telegram-safe HTML even when using Message.* helpers
@@ -120,5 +120,5 @@ class BoldFixBot(Bot):
                 setattr(method, "caption", convert_markdown_bold_to_html(caption))
         except Exception:
             pass
-        return await super().__call__(method)
+        return await super().__call__(method, *args, **kwargs)
 


### PR DESCRIPTION
Fix `BoldFixBot.__call__` to accept and forward arbitrary arguments to resolve `request_timeout` errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3c1df4b-9458-46a5-912b-f1f1ac5990aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3c1df4b-9458-46a5-912b-f1f1ac5990aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

