### PR TITLE
Show all plans for renewal and adjust limits

### DIFF
--- a/database.py
+++ b/database.py
@@ -222,6 +222,7 @@ class Database:
                     status TEXT NOT NULL DEFAULT 'pending',
                     order_type TEXT,
                     target_admin_id INTEGER,
+                    apply_as_reset BOOLEAN,
                     delta_traffic_bytes INTEGER,
                     delta_time_seconds INTEGER,
                     delta_users INTEGER,
@@ -259,6 +260,10 @@ class Database:
                 pass
             try:
                 await db.execute("ALTER TABLE orders ADD COLUMN target_admin_id INTEGER")
+            except aiosqlite.OperationalError:
+                pass
+            try:
+                await db.execute("ALTER TABLE orders ADD COLUMN apply_as_reset BOOLEAN")
             except aiosqlite.OperationalError:
                 pass
             try:

--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -455,7 +455,7 @@ async def admin_renew_panel(callback: CallbackQuery, state: FSMContext):
         intro = config.MESSAGES.get("renew_intro", "🔄 تمدید/افزایش محدودیت‌ها (تدریجی مجاز)")
     else:
         kb = InlineKeyboardMarkup(inline_keyboard=[
-            [InlineKeyboardButton(text="🔁 تمدید کامل پلن", callback_data=f"admin_full_renew_{admin_id}")],
+            [InlineKeyboardButton(text="🔁 تمدید کامل پلن (انتخاب پلن)", callback_data=f"admin_full_renew_{admin_id}")],
             [InlineKeyboardButton(text=config.BUTTONS["back"], callback_data="admin_renew")]
         ])
         intro = "🔄 تمدید کامل پلن (پرداخت کل هزینه پلن)"
@@ -470,25 +470,75 @@ async def admin_full_renew(callback: CallbackQuery):
     if not admin or admin.user_id != callback.from_user.id:
         await callback.answer("پنل یافت نشد.", show_alert=True)
         return
-    plan = await db.get_plan_by_id(getattr(admin, 'origin_plan_id', 0) or 0)
-    if not plan:
-        await callback.answer("پلن مبدا یافت نشد.", show_alert=True)
+    # Safeguard: only allow for full-renew-only cases
+    try:
+        override = getattr(admin, 'allow_incremental_renewal', None)
+        if override is not None and override:
+            await callback.answer("تمدید کامل اجباری نیست؛ می‌توانید از افزایش تدریجی استفاده کنید.", show_alert=True)
+            return
+        origin_plan = await db.get_plan_by_id(getattr(admin, 'origin_plan_id', 0) or 0)
+        plan_allows_incremental = bool(getattr(origin_plan, 'allow_incremental_renewal', True)) if origin_plan else True
+        if plan_allows_incremental and override is None:
+            await callback.answer("این پنل محدود به تمدید کامل نیست.", show_alert=True)
+            return
+    except Exception:
+        pass
+    # Show all active plans for selection (full-renew-only flow)
+    plans = await db.get_plans(only_active=True)
+    if not plans:
+        await callback.answer("هیچ پلن فعالی برای تمدید موجود نیست.", show_alert=True)
         return
+    from utils.notify import seconds_to_days
+    lines = ["🔁 تمدید کامل: یک پلن را برای تمدید انتخاب کنید:", ""]
+    for p in plans:
+        traffic_txt = "نامحدود" if p.traffic_limit_bytes is None else f"{await format_traffic_size(p.traffic_limit_bytes)}"
+        time_txt = "نامحدود" if p.time_limit_seconds is None else f"{seconds_to_days(p.time_limit_seconds)} روز"
+        users_txt = "نامحدود" if p.max_users is None else f"{p.max_users} کاربر"
+        price_txt = f"{p.price:,}"
+        lines.append(f"• {p.name}")
+        lines.append(f"  📦 ترافیک: {traffic_txt}")
+        lines.append(f"  ⏱️ زمان: {time_txt}")
+        lines.append(f"  👥 کاربر: {users_txt}")
+        lines.append(f"  💰 قیمت: {price_txt} تومان")
+        lines.append(f"   ➤ برای تمدید با این پلن بزنید: #ID {p.id}")
+        lines.append("—")
+    text = "\n".join(lines).rstrip("—")
+    kb_rows = [
+        [InlineKeyboardButton(text=f"تمدید با #{p.id} - {p.name}", callback_data=f"admin_full_renew_plan_{admin_id}_{p.id}")]
+        for p in plans
+    ]
+    kb_rows.append([InlineKeyboardButton(text=config.BUTTONS["back"], callback_data=f"admin_renew_panel_{admin_id}")])
+    await callback.message.edit_text(text, reply_markup=InlineKeyboardMarkup(inline_keyboard=kb_rows))
+    await callback.answer()
+
+
+@admin_router.callback_query(F.data.startswith("admin_full_renew_plan_"))
+async def admin_full_renew_plan_selected(callback: CallbackQuery):
+    parts = callback.data.split("_")
+    try:
+        admin_id = int(parts[-2])
+        plan_id = int(parts[-1])
+    except Exception:
+        await callback.answer("درخواست نامعتبر است.", show_alert=True)
+        return
+    admin = await db.get_admin_by_id(admin_id)
+    if not admin or admin.user_id != callback.from_user.id:
+        await callback.answer("پنل یافت نشد.", show_alert=True)
+        return
+    plan = await db.get_plan_by_id(plan_id)
+    if not plan:
+        await callback.answer("پلن انتخابی یافت نشد.", show_alert=True)
+        return
+    # Create renew order flagged as reset (apply_as_reset)
     order_id = await db.add_order(callback.from_user.id, plan_id=plan.id, price_snapshot=plan.price, plan_name_snapshot=f"تمدید کامل - {plan.name}")
     if not order_id:
         await callback.answer("خطا در ثبت سفارش تمدید.", show_alert=True)
         return
-    await db.update_order(
-        order_id,
-        order_type="renew",
-        target_admin_id=admin_id,
-        delta_traffic_bytes=plan.traffic_limit_bytes,
-        delta_time_seconds=plan.time_limit_seconds,
-        delta_users=None
-    )
+    await db.update_order(order_id, order_type="renew", target_admin_id=admin_id, apply_as_reset=1)
+    # Show payment instructions
     cards = await db.get_cards(only_active=True)
     lines = [
-        f"✅ سفارش تمدید کامل ثبت شد.\n\nشناسه سفارش: {order_id}\nپلن: {plan.name}\nقیمت: {plan.price:,} تومان\n",
+        f"✅ سفارش تمدید کامل ثبت شد.\n\nشناسه سفارش: {order_id}\nپلن انتخابی: {plan.name}\nقیمت: {plan.price:,} تومان\n",
         config.MESSAGES["public_payment_instructions"],
         "",
         "کارت‌های فعال:",

--- a/handlers/sudo_handlers.py
+++ b/handlers/sudo_handlers.py
@@ -3915,41 +3915,78 @@ async def order_approve(callback: CallbackQuery):
         if not admin:
             await callback.answer("پنل مقصد تمدید یافت نشد.", show_alert=True)
             return
-        delta_traffic = int(o.get("delta_traffic_bytes") or 0)
-        delta_time = int(o.get("delta_time_seconds") or 0)
-        delta_users = int(o.get("delta_users") or 0)
-        new_fields = {}
-        if delta_traffic:
-            new_fields["max_total_traffic"] = (admin.max_total_traffic or 0) + delta_traffic
-        if delta_time:
-            new_fields["max_total_time"] = (admin.max_total_time or 0) + delta_time
-        if delta_users:
-            new_fields["max_users"] = (admin.max_users or 0) + delta_users
-        if not new_fields:
-            await callback.answer("مقادیر تمدید نامعتبر است.", show_alert=True)
+        apply_as_reset = bool(o.get("apply_as_reset"))
+        if apply_as_reset:
+            # Reset limits to the selected plan's values
+            plan = await db.get_plan_by_id(int(o.get("plan_id"))) if o.get("plan_id") else None
+            if not plan:
+                await callback.answer("پلن انتخابی برای ریست یافت نشد.", show_alert=True)
+                return
+            from datetime import datetime as _dt
+            now = _dt.utcnow()
+            new_fields = {
+                "max_total_traffic": (plan.traffic_limit_bytes or 0),
+                "max_total_time": (plan.time_limit_seconds if plan.time_limit_seconds is not None else (36500 * 24 * 60 * 60)),
+                "max_users": (plan.max_users if plan.max_users is not None else 1000000),
+                "validity_days": ((plan.time_limit_seconds // 86400) if plan.time_limit_seconds else 36500),
+                "origin_plan_id": plan.id,
+                "created_at": now,
+            }
+            ok_update = await db.update_admin(admin.id, **new_fields)
+            if not ok_update:
+                await callback.answer("خطا در اعمال تمدید (ریست).", show_alert=True)
+                return
+            await db.update_order(oid, status="approved", approved_by=callback.from_user.id)
+            # Notify user
+            try:
+                bot = callback.bot
+                lines = [
+                    "✅ تمدید کامل اعمال شد (ریست محدودیت‌ها).",
+                    f"📦 پلن جدید: {plan.name}",
+                ]
+                await bot.send_message(chat_id=o['user_id'], text="\n".join(lines))
+            except Exception as e:
+                logger.error(f"Failed to notify user {o['user_id']} after reset-renew approve: {e}")
+            await callback.message.edit_text("✅ سفارش تایید و تمدید کامل اعمال شد.")
+            await callback.answer()
             return
-        ok_update = await db.update_admin(admin.id, **new_fields)
-        if not ok_update:
-            await callback.answer("خطا در اعمال تمدید.", show_alert=True)
-            return
-        await db.update_order(oid, status="approved", approved_by=callback.from_user.id)
-        # Notify user
-        try:
-            from utils.notify import format_traffic_size, format_time_duration
-            bot = callback.bot
-            lines = ["✅ تمدید اعمال شد.", ""]
+        else:
+            # Incremental renewal behavior (existing)
+            delta_traffic = int(o.get("delta_traffic_bytes") or 0)
+            delta_time = int(o.get("delta_time_seconds") or 0)
+            delta_users = int(o.get("delta_users") or 0)
+            new_fields = {}
             if delta_traffic:
-                lines.append(f"📦 افزایش ترافیک: +{await format_traffic_size(delta_traffic)}")
+                new_fields["max_total_traffic"] = (admin.max_total_traffic or 0) + delta_traffic
             if delta_time:
-                lines.append(f"⏱️ افزایش زمان: +{await format_time_duration(delta_time)}")
+                new_fields["max_total_time"] = (admin.max_total_time or 0) + delta_time
             if delta_users:
-                lines.append(f"👥 افزایش کاربر: +{delta_users}")
-            await bot.send_message(chat_id=o['user_id'], text="\n".join(lines))
-        except Exception as e:
-            logger.error(f"Failed to notify user {o['user_id']} after renewal approve: {e}")
-        await callback.message.edit_text("✅ سفارش تایید و تمدید اعمال شد.")
-        await callback.answer()
-        return
+                new_fields["max_users"] = (admin.max_users or 0) + delta_users
+            if not new_fields:
+                await callback.answer("مقادیر تمدید نامعتبر است.", show_alert=True)
+                return
+            ok_update = await db.update_admin(admin.id, **new_fields)
+            if not ok_update:
+                await callback.answer("خطا در اعمال تمدید.", show_alert=True)
+                return
+            await db.update_order(oid, status="approved", approved_by=callback.from_user.id)
+            # Notify user
+            try:
+                from utils.notify import format_traffic_size, format_time_duration
+                bot = callback.bot
+                lines = ["✅ تمدید اعمال شد.", ""]
+                if delta_traffic:
+                    lines.append(f"📦 افزایش ترافیک: +{await format_traffic_size(delta_traffic)}")
+                if delta_time:
+                    lines.append(f"⏱️ افزایش زمان: +{await format_time_duration(delta_time)}")
+                if delta_users:
+                    lines.append(f"👥 افزایش کاربر: +{delta_users}")
+                await bot.send_message(chat_id=o['user_id'], text="\n".join(lines))
+            except Exception as e:
+                logger.error(f"Failed to notify user {o['user_id']} after renewal approve: {e}")
+            await callback.message.edit_text("✅ سفارش تایید و تمدید اعمال شد.")
+            await callback.answer()
+            return
 
     # New panel purchase flow
     plan = await db.get_plan_by_id(int(o.get("plan_id"))) if o.get("plan_id") else None


### PR DESCRIPTION
Enable full plan renewal to allow selection of any active plan and reset user limits accordingly for admins restricted to full renewals.

---
<a href="https://cursor.com/background-agent?bcId=bc-919c6d41-28ec-44d7-acb5-25e6513d1cf7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-919c6d41-28ec-44d7-acb5-25e6513d1cf7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

