### PR TITLE
Add broadcast and active panel messaging

### DIFF
--- a/database.py
+++ b/database.py
@@ -433,6 +433,25 @@ class Database:
             print(f"Error getting all admins: {e}")
             return []
 
+    async def get_distinct_admin_user_ids(self, only_active: bool = False) -> List[int]:
+        """Return distinct Telegram user IDs of admins. Optionally filter by active panels.
+
+        When a user has multiple panels, they will appear only once in the result.
+        """
+        try:
+            async with aiosqlite.connect(self.db_path) as db_conn:
+                db_conn.row_factory = aiosqlite.Row
+                if only_active:
+                    query = "SELECT DISTINCT user_id FROM admins WHERE is_active = 1"
+                else:
+                    query = "SELECT DISTINCT user_id FROM admins"
+                async with db_conn.execute(query) as cursor:
+                    rows = await cursor.fetchall()
+                    return [int(r["user_id"]) for r in rows]
+        except Exception as e:
+            print(f"Error getting distinct admin user ids: {e}")
+            return []
+
     async def update_admin(self, admin_id: int, **kwargs) -> bool:
         """Update admin data by admin ID.
 


### PR DESCRIPTION
Add `get_distinct_admin_user_ids` to fetch unique admin user IDs, optionally filtered by active panels, to support broadcast messaging.

---
<a href="https://cursor.com/background-agent?bcId=bc-cdad90ff-883a-40b6-88f0-8f672fc436f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cdad90ff-883a-40b6-88f0-8f672fc436f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

